### PR TITLE
Bugfix in file extension

### DIFF
--- a/de.tu_bs.cs.isf.e4cf.core/src/de/tu_bs/cs/isf/e4cf/core/file_structure/components/File.java
+++ b/de.tu_bs.cs.isf.e4cf.core/src/de/tu_bs/cs/isf/e4cf/core/file_structure/components/File.java
@@ -20,7 +20,6 @@ public class File extends AbstractFileTreeElement {
 		super(path, null, new ArrayList<>());
 		checkFile(Paths.get(path));
 	}
-	
 
 	public File(String path, FileTreeElement parent) {
 		super(path, parent, new ArrayList<>());
@@ -30,50 +29,60 @@ public class File extends AbstractFileTreeElement {
 	public FileTreeElement create(CreateOperation createOp) throws IOException {
 		return createOp.execute(this);
 	}
-	
+
 	@Override
 	public FileTreeElement delete(DeleteOperation deleteOp) throws IOException {
 		return deleteOp.execute(this);
 	}
-	
+
 	@Override
 	public void move(MoveOperation moveOp) throws IOException {
 		moveOp.execute(this);
 	}
-	
+
 	@Override
 	public boolean isDirectory() {
 		return false;
 	}
 
+	/**
+	 * This method returns the file extension of the file. The file extension begins
+	 * at the last occurence of a dot (<code>.</code>). If no dot is present, then
+	 * an empty string is returned. These are some examples:
+	 * <ul>
+	 * <li><code>.htaccess</code> returns <code>htaccess</code>;
+	 * <li><code>exampleFile</code> returns an empty string;
+	 * <li><code>file.ext</code> returns <code>ext</code>;
+	 * <li><code>archive.tar.gz</code> returns <code>gz</code>.
+	 * </ul>
+	 * 
+	 * @return File Extension
+	 */
 	@Override
 	public String getExtension() {
 		String filename = _file.getFileName().toString();
 		String extension = "";
 		int extensionBeginIndex = filename.lastIndexOf(".");
 		if (extensionBeginIndex >= 0) {
-			extension = filename.substring(extensionBeginIndex+1);			
+			extension = filename.substring(extensionBeginIndex + 1);
 		}
 		return extension;
 	}
 
 	private void checkFile(Path path) {
 		if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
-			throw new RuntimeException("Underlying file system object is no regular file: "+path);
+			throw new RuntimeException("Underlying file system object is no regular file: " + path);
 		}
 	}
-
 
 	@Override
 	public void accept(TreeVisitor visitor) {
 		visitor.visit(this);
 	}
 
-
 	@Override
 	public <T> T getContent(LoadOperation<T> loadOp) {
 		return loadOp.execute(this);
 	}
-
 
 }

--- a/de.tu_bs.cs.isf.e4cf.core/src/de/tu_bs/cs/isf/e4cf/core/file_structure/components/File.java
+++ b/de.tu_bs.cs.isf.e4cf.core/src/de/tu_bs/cs/isf/e4cf/core/file_structure/components/File.java
@@ -51,7 +51,7 @@ public class File extends AbstractFileTreeElement {
 		String filename = _file.getFileName().toString();
 		String extension = "";
 		int extensionBeginIndex = filename.lastIndexOf(".");
-		if (extensionBeginIndex > 0) {
+		if (extensionBeginIndex >= 0) {
 			extension = filename.substring(extensionBeginIndex+1);			
 		}
 		return extension;

--- a/de.tu_bs.cs.isf.e4cf.core/src/de/tu_bs/cs/isf/e4cf/core/file_structure/components/File.java
+++ b/de.tu_bs.cs.isf.e4cf.core/src/de/tu_bs/cs/isf/e4cf/core/file_structure/components/File.java
@@ -49,8 +49,12 @@ public class File extends AbstractFileTreeElement {
 	@Override
 	public String getExtension() {
 		String filename = _file.getFileName().toString();
-		int extensionBeginIndex = filename.indexOf(".");
-		return filename.substring(extensionBeginIndex+1);
+		String extension = "";
+		int extensionBeginIndex = filename.lastIndexOf(".");
+		if (extensionBeginIndex > 0) {
+			extension = filename.substring(extensionBeginIndex+1);			
+		}
+		return extension;
 	}
 
 	private void checkFile(Path path) {


### PR DESCRIPTION
The file extension was returned wrongly. The file extension was returned beginning from the first index of dot or the complete file name when no dot was present. This behavior is changed with this pull request.

| Example | Previously | Now |
|-|-|-|
| `.example` | `example` | `example` |
| `example` | `example` | `` (empty String => no extension) |
| `example.ext` | `ext` | `ext` |
| `example.noext.ext` | `noext.ext` | `ext` |

